### PR TITLE
fixes meetup events api request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,38 @@
+[![Netlify Status](https://api.netlify.com/api/v1/badges/b819e860-1012-4e2a-958a-6a9c809a5142/deploy-status)](https://app.netlify.com/sites/fenders/deploys)
+
 # Fenders Website
-- The Fenders Perth Meetup website.
+
+-   The Fenders Perth Meetup website.
 
 ## TODO
+
 Check issues for current items or create an issue if you have anything in mind.
 
 ## Meetup events
+
 Events are pulled from the Meetup API using this endpoint:
 https://www.meetup.com/meetup_api/docs/:urlname/events/#list
 
 ### Required
+
 :urlname = Front-End-Web-Developers-Perth
 
 This means supplying an env variable `MEETUP_API` in dev and prod.
 Meetup API Key: https://secure.meetup.com/meetup_api/key/
 
 ## Running in development
-`MEETUP_API={API KEY} yarn start`
+
+`yarn start`
 
 ## Git Workflow
+
 Get in touch with one of the organisers to get access to the repository :smiley:
-1. To make changes, create a new branch off `dev` as a `feature-branch` to perform the work
-2. Submit a PR to merge your `feature-branch` into `dev`, and get someone from `fendersperth/fenders-website` to approve it (add them to the review and they'll get a notification)
-3. Once someone has approved the request, merge it into `dev` :+1:
-4. When you've merged it, someone from `fendersperth/fenders-website` will submit a PR to merge from `dev` into `master`
-5. Someone else from `fendersperth/fenders-website` or one of the organisers will then approve the request to merge into `master` and deploy the site, pending whether status checks pass :tada:
+
+1. To make changes, create a new branch off `master` as a `feature-branch` to perform the work
+2. Submit a PR to merge your `feature-branch` into `master`, and get someone from `fendersperth/fenders-website` to approve it (add them to the review and they'll get a notification)
+3. Once someone has approved the request, merge it into `master` :+1:
 
 ## Getting approval access
+
 Want to help us on the website? We'd love you to help!
 Contact one of the Fenders Organisers and we can discuss adding you as a maintainer on the website

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,3 @@
-if (typeof process.env.MEETUP_API === 'undefined') {
-    throw new Error('MEETUP_API env var must be defined. See README')
-}
-
 module.exports = {
     siteMetadata: {
         title: 'Fenders',
@@ -17,9 +13,7 @@ module.exports = {
         {
             resolve: 'gatsby-source-meetup',
             options: {
-                apiURL: `https://api.meetup.com/Front-End-Web-Developers-Perth/events?key=${
-                    process.env.MEETUP_API
-                    }`,
+                apiURL: `https://api.meetup.com/Front-End-Web-Developers-Perth/events`,
             },
         },
     ],


### PR DESCRIPTION
Meetup isn't supporting api-key authorisation but fortunately this endpoint doesn't need it anymore either. So we can just call it.